### PR TITLE
Migrate to Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7
 
-LABEL maintainer="samuel.gratzl@datavisyn.io"
+LABEL maintainer="contact@caleydo.org"
 LABEL description="This is a base image for phovea server docker images" 
 LABEL vendor="The Caleydo Team"
 LABEL version="1.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7
 LABEL maintainer="contact@caleydo.org"
 LABEL description="This is a base image for phovea server docker images" 
 LABEL vendor="The Caleydo Team"
-LABEL version="1.1"
+LABEL version="2.0"
 
 
 COPY requirements*.txt docker_packages.txt ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.7
 
 LABEL maintainer="contact@caleydo.org"
 LABEL description="This is a base image for phovea server docker images" 

--- a/docker_packages.txt
+++ b/docker_packages.txt
@@ -1,1 +1,0 @@
-libhdf5-serial-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,5 @@ pandas==0.25.0
 matplotlib==2.2.2
 Pillow==5.1.0
 json-cfg==0.4.2
-tables==3.4.2
 redis==2.10.6
 pymongo==3.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ pandas==0.25.0
 matplotlib==2.2.2
 Pillow==5.1.0
 json-cfg==0.4.2
-redis==2.10.6
 pymongo==3.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ pandas==0.25.0
 matplotlib==2.2.2
 Pillow==5.1.0
 json-cfg==0.4.2
-pymongo==3.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 Flask==0.12.2
 flask-restplus==0.10.1
 Flask-Sockets==0.2.1
-gevent==1.2.2
+gevent==1.4.0
 gevent-websocket==0.10.1
-numpy==1.14.2
-scipy==1.0.1
-pandas==0.22.0
+numpy==1.17.0
+scipy==1.3.1
+pandas==0.25.0
 matplotlib==2.2.2
 Pillow==5.1.0
 json-cfg==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,6 @@ pandas==0.25.0
 matplotlib==2.2.2
 Pillow==5.1.0
 json-cfg==0.4.2
-future==0.16.0
-backports.csv==1.0.5
 tables==3.4.2
 redis==2.10.6
 pymongo==3.6.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,4 +3,4 @@ pep8-naming==0.5.0
 pytest==3.5.0
 pytest-runner==4.2
 Sphinx==1.7.2
-recommonmark==0.4.0
+recommonmark==0.6.0


### PR DESCRIPTION
* Use Docker base image `python:3.7`
* Update Python requirements, where necessary (should match with phovea_server requirements)
* Remove dependencies for [phovea_data_hdf](https://github.com/phovea/phovea_data_hdf), [phovea_data_redis](https://github.com/phovea/phovea_data_redis), [phovea_data_mongo](https://github.com/phovea/phovea_data_mongo) (the dependencies will be installed on-demand, when adding plugin to the workspace)
* Update Dockerfile version to v2.0